### PR TITLE
Simplify setup for new projects

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,66 @@
+name: 'AWS Config Sandbox'
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  terraform:
+    name: 'TF GitHub Actions'
+    runs-on: ubuntu-latest
+    environment: production
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 1.0.0
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        # aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }} 
+        # if you have/need it
+        aws-region: us-east-1
+
+    - name: Terraform Init
+      id: init
+      run: terraform init
+
+    - name: Terraform Format
+      id: fmt
+      run: terraform fmt -check
+      env:
+        TF_ACTION_WORKING_DIR: .
+      continue-on-error: true
+
+    - name: Terraform Validate
+      id: validate
+      run: terraform validate -no-color
+
+    - name: Terraform Plan
+      id: plan
+      if: github.event_name == 'pull_request'
+      run: terraform plan -no-color
+      continue-on-error: true
+
+    - name: Terraform Plan Status
+      if: steps.plan.outcome == 'failure'
+      run: exit 1
+
+    - name: Terraform Apply
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: terraform apply -auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,106 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+*.sublime-workspace
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# Created by https://www.gitignore.io/api/terraform
+
+### Terraform ###
+# Terraform - https://terraform.io/
+.terraform
+terraform.tfstate
+terraform.tfstate.backup
+*.tfvars
+
+### Terraform Patch ###
+# End of https://www.gitignore.io/api/terraform

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/aws" {
   version = "3.59.0"
   hashes = [
+    "h1:3QooXDYCyIkmrxQq/rWYcaVh5Yz/7U+EJ2j0QiN67uA=",
     "h1:HRPBFFbe9VGPvFGHUeOLZOmOdSh+RmkirN0FXuMxA44=",
     "zh:0b33154c805071af15839184f3faafeb1549d26a2f1fe721393461790c5ddb46",
     "zh:1c5c6793cbec328394c6dda686298d9f6bb7b4c6a39e3dc48dc3035dea9aeda0",

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # Terraform AWS Bootstrap
 
-This project is to perform the intitial bootstrapping of Terraform in an AWS account. 
+This project is to perform the intitial bootstrapping of Terraform in an AWS account. It creates an S3 bucket and DynamoDB Table for Terraform state management using an S3 Remote backend configuration. This is a low-cost, simple way to manage an AWS project using Infrastructure as Code.
 
+## Prerequisites
 - The IAM setup to allow this run to build things in the account is not included, this should be a seperate external step
-- The AWS credentials / permissions for Terraform to assume are external to this module
-- The backend should be set to local for the initial apply
-- After the state bucket and locking table are created, run a second apply to switch to remote s3 backend
+- The AWS credentials / permissions for Terraform to assume are external to this
+- The CICD configuration is external to this module
+
+## Setup
+1. In main.tf on line 2, update `my-project` with your project name.
+2. Create the S3 Bucket and Dynamodb locking table.
+  - `terraform init`
+  - `terraform apply`
+3. Switch to S3 remote backend
+  - In maint.tf, remove the comments from lines 22-28
+  - `terraform init`
+  - `terraform apply`

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
+locals {
+  project_name = "my-project"
+  account_id = data.aws_caller_identity.current.account_id
+}
+
 #################
 ### Bootstrap ###
 #################
@@ -5,8 +10,8 @@
 # Build an S3 bucket and DynamoDB for Terraform state and locking
 module "bootstrap" {
   source                  = "./modules/bootstrap"
-  tfstate_bucket          = "project-name-terraform-tfstate"
-  tf_lock_dynamo_table    = "project-name-dynamodb-terraform-locking"
+  tfstate_bucket          = "${local.project_name}-${local.account_id}-terraform-tfstate"
+  tf_lock_dynamo_table    = "${local.project_name}-${local.account_id}-dynamodb-terraform-locking"
 }
 
 ############################
@@ -15,10 +20,10 @@ module "bootstrap" {
 # This should be commented out for the first terraform apply so that the tfstate bucket and locking table can be built. After the initial apply, uncomment the s3 backend code and run another apply.
 terraform {
 #   backend "s3" {
-#     bucket         = "shooting-insights-terraform-tfstate"
+#     bucket         = "${local.project_name}-${local.account_id}-terraform-tfstate"
 #     key            = "terraform.tfstate"
 #     region         = "us-east-1"
-#     dynamodb_table = "shooting-insights-dynamodb-terraform-locking"
+#     dynamodb_table = "${local.project_name}-${local.account_id}-dynamodb-terraform-locking"
 #     encrypt        = true
 #   }
 }
@@ -35,9 +40,8 @@ provider "aws" {
   default_tags {
    tags = {
      Terraform   = "true"
-     Environment = "Test"
-     Owner       = "Name"
-     Project     = "TerraformAWSBootstrap"
+     Owner       = "${local.project_name}"
+     Project     = "${local.project_name}"
    }
  }
 }


### PR DESCRIPTION
Use locals to make the boilerplate config faster and include a few nice to have project items such as pre-commit and .github actions boilerplate CICD config. The purpose of this work is to have a central source for AWS bootstrapping which includes the tooling I like to use.